### PR TITLE
use os.Stderr instead of flag.CommandLine.Output

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,8 +45,8 @@ func brighten(r uint8, add uint8) uint8 {
 func main() {
 	// command line parsing
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] [input] [output]\n", os.Args[0])
-		fmt.Fprintf(flag.CommandLine.Output(), "   or: %s [options] - (for stdin+stdout processing)\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [options] [input] [output]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "   or: %s [options] - (for stdin+stdout processing)\n", os.Args[0])
 		flag.PrintDefaults()
 	}
 	magPtr := flag.Float64("mag", 7.0, "dissolve blur strength")


### PR DESCRIPTION
this fixes compilation on golang 2:1.7~5 (Debian 9 stretch)
Fixes https://github.com/r00tman/corrupter/issues/7