### PR TITLE
Don't move pixel values to other side of screen

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,10 +22,10 @@ func check(e error) {
 // force x to stay in [0, b) range. x is assumed to be in [-b,2*b) range
 func wrap(x, b int) int {
 	if x < 0 {
-		return x + b
+		return 0
 	}
 	if x >= b {
-		return x - b
+		return b - 1
 	}
 	return x
 }


### PR DESCRIPTION
I was getting some distortion on the edge of a black screen section (looks like bleed from the other side of the screen, see first image below), this fixes that issue.  I might be missing something else you were trying to do though!

## Before
![bleed](https://user-images.githubusercontent.com/2412457/95015072-441d0b00-064b-11eb-8f94-2b4dfbff06ca.png)


## After
![no-bleed](https://user-images.githubusercontent.com/2412457/95015071-42ebde00-064b-11eb-8bd4-22ef2ed566b8.png)